### PR TITLE
Fix "undefined: JsContext" by installing gcc (Documentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The package is fully go-getable, So, just type
 
 to install.
 
+Also make sure you have `gcc` installed. On Debian/Ubuntu based systems, just type
+
+`sudo apt install gcc`
+
 ### Usage
 
 #### 1. Evaluates expressions


### PR DESCRIPTION
Note for Linux: If you get "undefined: JsContext" when trying the build or run the examples, you need to install the package "gcc", as Duktape needs to be compiled too for it to work.